### PR TITLE
Disable printout in test

### DIFF
--- a/tests/test_get_value_at_indices.f90
+++ b/tests/test_get_value_at_indices.f90
@@ -124,10 +124,10 @@
     status = m%finalize()
 
     ! Visual inspection.
-    write(*,*) "Test 6 get values"
-    call print_1darray(tval, shape(2))
-    write(*,*) "Test 6 expected values"
-    call print_1darray(expected, shape(2))
+    ! write(*,*) "Test 6 get values"
+    ! call print_1darray(tval, shape(2))
+    ! write(*,*) "Test 6 expected values"
+    ! call print_1darray(expected, shape(2))
 
     code = BMI_SUCCESS
     do i = 1, shape(2)


### PR DESCRIPTION
This PR disables the printout of values that causes one of the tests in `test_get_value_at_indices.f90` to fail. The issue is with the fixture *print_1darray*, and my hunch is that this is the result of a change in the compiler, since this test passed the last time it was run in 2020.

This is absolutely a band-aid approach. It would be better to update *print_1darray*. However, this is an optional (for human eyes only) part of a test, so to save time, I've chosen to disable it. It might be worth writing up an issue to fix *print_1darray* at a later point.